### PR TITLE
Mark online edition as second (corrected) printing in preparation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 Manifest.toml
 index.tex
 *.tex
+!_copyright-page.tex
 _freeze/*
 artifacts/*
 jl_*/

--- a/_copyright-page.tex
+++ b/_copyright-page.tex
@@ -1,0 +1,48 @@
+\thispagestyle{empty}
+\vspace*{\fill}
+\begin{center}
+\begin{minipage}{0.85\textwidth}
+\centering
+
+\textit{Modern Financial Modeling: Concepts and Applications for Actuaries and Other Financial Professionals}
+
+\bigskip
+
+Copyright \textcopyright{} 2026 Alec Loudenback and Yun-Tien Lee.
+
+\medskip
+
+Published by Alec Loudenback and Yun-Tien Lee.
+
+\medskip
+
+This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License (CC BY-NC-SA 4.0), except where otherwise noted. To view a copy of this license, visit \url{https://creativecommons.org/licenses/by-nc-sa/4.0/}.
+
+\medskip
+
+The chapters on developing in Julia (\emph{Writing Julia}, \emph{Debugging Julia}, \emph{Sharing Julia}, and \emph{Optimizing Julia}) are licensed under the Creative Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0). To view a copy of this license, visit \url{https://creativecommons.org/licenses/by-sa/4.0/}.
+
+\medskip
+
+This is not a Milliman-sponsored project.
+
+\bigskip
+
+ISBN 978-1-257-97605-8
+
+\medskip
+
+First edition, second (corrected) printing, 2026.
+
+\medskip
+
+Corrections since the first printing (v1.0.2) are listed at \url{https://ModernFinancialModeling.com/errata.html}.
+
+\medskip
+
+Published online at \url{https://ModernFinancialModeling.com}.
+
+\end{minipage}
+\end{center}
+\vspace*{\fill}
+\clearpage

--- a/copyright.qmd
+++ b/copyright.qmd
@@ -15,7 +15,9 @@ This is not a Milliman-sponsored project.
 
 ISBN 978-1-257-97605-8
 
-First edition (v1.0.2), 2026.
+First edition, 2026. Printed copies correspond to the first printing (v1.0.2, February 2026).
+
+This online edition is updated continuously and incorporates corrections made since the first printing — a second, corrected printing in preparation. See the [errata](errata.qmd) for details.
 
 Published online at [ModernFinancialModeling.com](https://ModernFinancialModeling.com).
 :::
@@ -35,7 +37,9 @@ This is not a Milliman-sponsored project.
 
 ISBN 978-1-257-97605-8
 
-First edition (v1.0.2), 2026.
+First edition, 2026. Printed copies correspond to the first printing (v1.0.2, February 2026).
+
+This online edition is updated continuously and incorporates corrections made since the first printing — a second, corrected printing in preparation. See the [errata](errata.qmd) for details.
 
 Published online at [ModernFinancialModeling.com](https://ModernFinancialModeling.com).
 :::

--- a/index.qmd
+++ b/index.qmd
@@ -9,6 +9,8 @@ The goal is straightforward: to empower financial professionals with the knowled
 This book is available in [HTML](http://ModernFinancialModeling.com) and [PDF](http://ModernFinancialModeling.com/Modern-Financial-Modeling.pdf). 
 
 ::: {.content-visible when-format="html"}
+*You are reading the online edition, which incorporates corrections made since the printed first printing (v1.0.2) — see the [errata](errata.qmd).*
+
 <p>A print version is also available:</p>
 <a href="purchase.html" class="btn btn-primary btn-lg mt-2 mb-2">Purchase Print Edition</a>
 :::


### PR DESCRIPTION
Adopts the standard printing-statement convention to distinguish the continuously updated online edition from the printed first printing (v1.0.2), until a new print run is published:

- **Site + epub copyright page**: "First edition, 2026. Printed copies correspond to the first printing (v1.0.2, February 2026)." followed by a note that the online edition incorporates post-printing corrections — a second, corrected printing in preparation — with a link to the errata page.
- **PDF copyright page** (`_copyright-page.tex`): same statement ("First edition, second (corrected) printing, 2026.") with the errata URL; also removes the leftover **Special Edition** label so the main-branch PDF reflects the regular edition (consistent with the regular ISBN 978-1-257-97605-8 it already carries).
- **Preface**: one visible line telling online readers they're reading the corrected edition, linking the errata.
- **Repo fix**: `_copyright-page.tex` was matched by the blanket `*.tex` ignore rule even though `_quarto.yml` requires it for the PDF build — fresh clones couldn't render the book. Added a `!_copyright-page.tex` exception and tracked the file.

After merge, a `quarto render` + publish is needed to update the site (no code cells affected — only copyright/index/PDF assembly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)