### PR TITLE
Clarify PDF copyright page: corrected print run not yet published

### DIFF
--- a/_copyright-page.tex
+++ b/_copyright-page.tex
@@ -32,11 +32,11 @@ ISBN 978-1-257-97605-8
 
 \medskip
 
-First edition, second (corrected) printing, 2026.
+First edition, 2026.
 
 \medskip
 
-Corrections since the first printing (v1.0.2) are listed at \url{https://ModernFinancialModeling.com/errata.html}.
+This PDF corresponds to the online edition, which incorporates corrections made since the first printing (v1.0.2, February 2026); a corrected print run has not yet been published. Printed copies currently available are the first printing. Corrections are listed at \url{https://ModernFinancialModeling.com/errata.html}.
 
 \medskip
 


### PR DESCRIPTION
Follow-up to #377: the PDF copyright page said "First edition, second (corrected) printing, 2026.", which implies that printing has already been published. The purchasable print copies are still the first printing (v1.0.2).

New wording states what this artifact actually is:

> First edition, 2026.
>
> This PDF corresponds to the online edition, which incorporates corrections made since the first printing (v1.0.2, February 2026); a corrected print run has not yet been published. Printed copies currently available are the first printing. Corrections are listed at ModernFinancialModeling.com/errata.html.

When the corrected print run is actually published, this block should be updated to a plain "second (corrected) printing" statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)